### PR TITLE
Add a way to apply an across-the-board 11.7% increase to all departments

### DIFF
--- a/app/src/components/BodyContent/Fund/index.js
+++ b/app/src/components/BodyContent/Fund/index.js
@@ -8,6 +8,13 @@ import styles from '../styles.scss';
 let dollarAmout = "$969.2 Million"
 
 class Fund extends Component {
+  handleClick(percentChange) {
+    return () => {
+      this.props.changeDepartmentAmount('all', percentChange);
+      this.props.updateServiceSpendingAmount();
+    };
+  }
+
   render() {
     return (
       <div>
@@ -38,9 +45,25 @@ class Fund extends Component {
 
             <p>It is also effected when City Council votes to change tax and service rates.</p>
 
-            <p> It is politically unpopular for the council to increase taxes in any way.</p>
+            <p>It is politically unpopular for the council to increase taxes in any way.</p>
+
+            <p>There is a an %11.76 increase in the amount money in the General Fund over last year. To start the budget process, you can either apply an %11.7 increase to all departments or begin with last years budget and a surplus of money.</p>
           </div>
-           <Link className={`${styles.buttonSolid} btn btn-lg btn-success`} role="button" to="/services">Continue to services</Link>
+          <div>
+            <div
+              className={`${styles.buttonSolid} btn btn-lg btn-success`}
+              onClick={this.handleClick(11.7).bind(this)}
+              role="button">
+                Apply 11.7% increase to all departments
+            </div>
+            <div
+              className={`${styles.buttonSolid} btn btn-lg btn-success`}
+              onClick={this.handleClick(0).bind(this)}
+              role="button">
+                Apply 0% change to all departments
+            </div>
+          </div>
+          <Link className={`${styles.buttonSolid} btn btn-lg btn-success`} role="button" to="/services">Continue to services</Link>
         </div>
         <NavBottom props={this.props}/>
       </div>

--- a/app/src/components/BodyContent/Fund/index.js
+++ b/app/src/components/BodyContent/Fund/index.js
@@ -47,7 +47,7 @@ class Fund extends Component {
 
             <p>It is politically unpopular for the council to increase taxes in any way.</p>
 
-            <p>There is a an %11.76 increase in the amount money in the General Fund over last year. To start the budget process, you can either apply an %11.7 increase to all departments or begin with last years budget and a surplus of money.</p>
+            <p>There is a an %11.76 increase in the amount money in the General Fund over last year. To start the budget process, you can either apply an %11.7 increase to all departments or begin with last year's budget and a surplus of money.</p>
           </div>
           <div>
             <div

--- a/app/src/reducers/data/index.js
+++ b/app/src/reducers/data/index.js
@@ -9,7 +9,7 @@ import {
   RESET_DEPARTMENT_AMOUNT,
 } from 'constants/ActionTypes';
 
-function replacedDepartmentState(state, departmentId, departmentUpdate) {
+function replacedDepartmentState(state, departmentUpdate) {
   let percentChange = state.percentChange + departmentUpdate;
   percentChange = percentChange < -100 ? -100 : percentChange;
   const amount = state.lastYearAmount * (1 + (percentChange / 100));
@@ -24,12 +24,20 @@ function resetDepartmentState(state) {
 function reducer(state = InitialState.data, action = {}) {
   switch (action.type) {
     case CHANGE_DEPARTMENT_AMOUNT:
-      const updatingDepartmentIndex = action.department - 1;
-      const updatedDepartments = [
-        ...state.departments.slice(0, updatingDepartmentIndex),
-        replacedDepartmentState(state.departments[updatingDepartmentIndex], action.department - 1, action.amount),
-        ...state.departments.slice(action.department),
-      ];
+      let updatedDepartments;
+      if (action.department === 'all') {
+        updatedDepartments = state.departments.map((departmentState) => {
+          const resetState = resetDepartmentState(departmentState);
+          return replacedDepartmentState(resetState, action.amount);
+        });
+      } else {
+        const updatingDepartmentIndex = action.department - 1;
+        updatedDepartments = [
+          ...state.departments.slice(0, updatingDepartmentIndex),
+          replacedDepartmentState(state.departments[updatingDepartmentIndex], action.amount),
+          ...state.departments.slice(action.department),
+        ];
+      }
       return Object.assign({}, state, { departments: updatedDepartments });
     case UPDATE_SERVICE_SPENDING_AMOUNT:
       const servicesSum = sum(state.departments.map((d) => d.amount));


### PR DESCRIPTION
This adds two buttons to the `/fund` page for applying across-the-board percent changes to the different departments. 

There's definitely some room for improvement in terms of wording and UX, but it gets the job done. Looks like this:

![](http://g.recordit.co/AGBLoscdsg.gif)
