### PR TITLE
recalculate total funds available and spending totals on reset

### DIFF
--- a/app/src/actions/funds.js
+++ b/app/src/actions/funds.js
@@ -1,6 +1,6 @@
 export function changeRemainingFundsAmout(services) {
   return {
-    type: 'CHANGE_REMAINGING_FUNDS_AMOUNT',
+    type: 'CHANGE_REMAINING_FUNDS_AMOUNT',
     services,
   };
 }

--- a/app/src/components/PartyLevelHeader.js
+++ b/app/src/components/PartyLevelHeader.js
@@ -16,16 +16,16 @@ const getSign = (number) => {
 }
 
 const PartyLevelHeader = (props) => {
-  const { service, department } = props
+  const { service, services, department, departments } = props;
 
   const isServiceComplete = department ? false : service.status === 'complete'
   const isUnstarted = department && department.amount === null
   const isInProgress = department && department.amount !== null
   const imgCssClass = isServiceComplete ? 'PartyLevelHeader__image--complete' : 'PartyLevelHeader__image'
 
-  const handleReset = (deptId) => {
-    props.resetBudgetAmount(deptId)
-  }
+  const handleReset = (deptId, departments, service, services) => {
+    props.resetBudgetAmount(deptId, departments, service, services);
+  };
 
   const renderFinishedOverlay = (serv) => {
     const sign = getSign(serv)
@@ -68,7 +68,7 @@ const PartyLevelHeader = (props) => {
             maximumFractionDigits={0}
           />
         </h2>
-        <span className="PartyLevelHeader__reset" onClick={handleReset.bind(this, dept.deptId)}>
+        <span className="PartyLevelHeader__reset" onClick={handleReset.bind(this, dept.deptId, departments, service, services)}>
           Reset
         </span>
       </div>
@@ -123,6 +123,7 @@ PartyLevelHeader.propTypes = {
     status: PropTypes.string,
     title: PropTypes.string,
   }).isRequired,
+  services: PropTypes.arrayOf(PropTypes.object).isRequired,
   department: PropTypes.shape({
     amount: PropTypes.number,
     amount2015: PropTypes.number,

--- a/app/src/containers/Department.js
+++ b/app/src/containers/Department.js
@@ -63,13 +63,13 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(recalculateServiceAmount(serviceIndex, departments))
       dispatch(changeRemainingFundsAmout(services))
     },
-    resetBudgetAmount: (deptId) => {
-      dispatch(resetDepartmentPercentChange(deptId))
-      // dispatch(recalculateServiceAmount(service.index, departments))
-      // dispatch(changeRemainingFundsAmout(services))
+    resetBudgetAmount: (deptId, departments, service, services) => {
+      dispatch(resetDepartmentPercentChange(deptId));
+      dispatch(recalculateServiceAmount(service.index, departments));
+      dispatch(changeRemainingFundsAmout(services));
     },
-  }
-}
+  };
+};
 
 const DepartmentContainer = connect(
   mapStateToProps,

--- a/app/src/reducers/funds.js
+++ b/app/src/reducers/funds.js
@@ -2,7 +2,7 @@ import InitialState from '../config/InitialState';
 
 function funds(state = InitialState.funds, action = {}) {
   switch (action.type) {
-    case 'CHANGE_REMAINGING_FUNDS_AMOUNT':
+    case 'CHANGE_REMAINING_FUNDS_AMOUNT':
       const newFunds = state
       const sumOfServiceSpending = action.services.reduce((memo, service) => {
         if (!Number(service.amount)) return memo


### PR DESCRIPTION
Fixes #159: After you reset, recalculate service amount and change remaining funds amount

Noticed that totals aren't set when the page loads - not sure if that was intended behavior or not.