### PR TITLE
Making the Landing Page Desktop Friendly

### DIFF
--- a/app/src/index.css
+++ b/app/src/index.css
@@ -1128,8 +1128,7 @@ button::-moz-focus-inner {
 
 #landing .container {
   margin: 0 auto;
-  text-align: center;
-  max-width: 500px; }
+  text-align: center; }
 
 #landing .btn {
   padding: 1em 2em;
@@ -1156,46 +1155,51 @@ button::-moz-focus-inner {
   background-color: #D5F6FF; }
 
 .btn-cta {
-  margin: 1em 0;
-  display: inline-block; }
+  display: inline-block;
+  margin: 1em 0; }
 
 #landing .section {
+  margin: auto;
   padding: 2em;
   position: relative;
   text-align: center; }
 
 #landing .section-secondary {
-  color: #ffffff; }
+  color: #ffffff;
+  max-width: 100%; }
 
 #landing .section-secondary::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: -5px;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-  background: #2FAFDE;
-  transform: skewY(1.5deg);
   -webkit-backface-visibility: hidden;
-  backface-visibility: hidden; }
+  backface-visibility: hidden;
+  background: #2FAFDE;
+  content: '';
+  height: 100%;
+  left: 0;
+  max-width: 100%;
+  position: absolute;
+  top: -5px;
+  transform: skewY(1.5deg);
+  width: 100%;
+  z-index: -1; }
 
 #landing .section-tertiary {
   background-color: #D5F6FF;
-  color: #ffffff; }
+  color: #ffffff;
+  max-width: 100%; }
 
 #landing .section-tertiary::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: -5px;
-  width: 100%;
-  height: 50%;
-  z-index: -1;
-  background: #2FAFDE;
-  transform: skewY(-1.5deg);
   -webkit-backface-visibility: hidden;
-  backface-visibility: hidden; }
+  backface-visibility: hidden;
+  background: #2FAFDE;
+  content: '';
+  height: 50%;
+  left: 0;
+  max-width: 100%;
+  position: absolute;
+  top: -5px;
+  transform: skewY(-1.5deg);
+  width: 100%;
+  z-index: -1; }
 
 #landing .header-light {
   color: #fff; }
@@ -1210,22 +1214,35 @@ button::-moz-focus-inner {
   max-width: 50%;
   margin: 2em auto; }
 
+@media (min-width: 1000px) {
+  #landing .icon-voice {
+    max-width: 300px; } }
+
+@media (min-width: 1900px) {
+  #landing .icon-voice {
+    max-width: 400px; } }
+
 .screens-container {
   position: relative;
-  height: 500px;
-  margin: 1em 0; }
-
-@media (min-width: 400px) {
-  .screens-container {
-    height: 600px; } }
-
-@media (min-width: 480px) {
-  .screens-container {
-    height: 650px; } }
+  height: 250px;
+  margin: auto;
+  max-width: 75%; }
 
 @media (min-width: 600px) {
   .screens-container {
-    height: 300px; } }
+    height: 300px;
+    max-width: 60%; } }
+
+@media (min-width: 900px) {
+  .screens-container {
+    margin: auto;
+    max-width: 700px;
+    height: 500px; } }
+
+@media (min-width: 1900px) {
+  .screens-container {
+    max-width: 800px;
+    height: 600px; } }
 
 .bg-confetti {
   display: none; }
@@ -1241,20 +1258,13 @@ button::-moz-focus-inner {
     margin: auto; } }
 
 .icon-screens {
-  position: absolute;
-  max-width: 200%;
+  max-width: 80%;
+  z-index: 2;
   margin: auto;
-  left: -50%; }
-
-@media (min-width: 600px) {
-  .icon-screens {
-    max-width: 80%;
-    z-index: 2;
-    margin: auto;
-    position: absolute;
-    top: 50px;
-    left: 0;
-    right: 0; } }
+  position: absolute;
+  top: 50px;
+  left: 0;
+  right: 0; }
 
 .bubble-list,
 .link-list {
@@ -1273,6 +1283,17 @@ button::-moz-focus-inner {
 .bubble img {
   border-radius: 100px; }
 
+@media (min-width: 600px) {
+  .link-list {
+    -webkit-flex-flow: row wrap;
+    flex-flow: row wrap;
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+    justify-content: space-around; } }
+
 html, body, #root,
 .container, .row,
 .intro {
@@ -1289,7 +1310,6 @@ body {
 
 @media (min-width: 600px) {
   .container, .Navigation {
-    width: 500px;
     margin: auto; }
   .Navigation {
     box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 0px; } }

--- a/app/src/index.scss
+++ b/app/src/index.scss
@@ -42,21 +42,10 @@ body {
   color: $text-color;
 }
 
-
 @media (min-width: 600px) {
   .container, .Navigation {
-    width: 500px;
     margin: auto;
   }
-  //
-  // .container .home,
-  // .container .intro,
-  // .container .Dashboard__body,
-  // .container .Service,
-  // .container .Navigation {
-  //   margin: auto;
-  //   width: 500px;
-  // }
 
   .Navigation {
     box-shadow: rgba(0, 0, 0, 0.1) 0px 2px 0px;

--- a/app/src/sass/_Landing.scss
+++ b/app/src/sass/_Landing.scss
@@ -52,7 +52,6 @@
 #landing .container {
   margin: 0 auto;
   text-align: center;
-  max-width: 500px;
 }
 
 #landing .btn {
@@ -85,11 +84,12 @@
 }
 
 .btn-cta {
-  margin: 1em 0;
   display: inline-block;
+  margin: 1em 0;
 }
 
 #landing .section {
+  margin: auto;
   padding: 2em;
   position: relative;
   text-align: center;
@@ -97,39 +97,45 @@
 
 #landing .section-secondary {
   color: #ffffff;
+  max-width: 100%;
 }
 
 #landing .section-secondary::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: -5px;
-  width: 100%;
-  height: 100%;
-  z-index: -1;
-  background: #2FAFDE;
-  transform: skewY(1.5deg);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
+
+  background: #2FAFDE;
+  content: '';
+  height: 100%;
+  left: 0;
+  max-width: 100%;
+  position: absolute;
+  top: -5px;
+  transform: skewY(1.5deg);
+  width: 100%;
+  z-index: -1;
 }
 
 #landing .section-tertiary {
   background-color: #D5F6FF;
   color: #ffffff;
+  max-width: 100%;
 }
 
 #landing .section-tertiary::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: -5px;
-  width: 100%;
-  height: 50%;
-  z-index: -1;
-  background: #2FAFDE;
-  transform: skewY(-1.5deg);
   -webkit-backface-visibility: hidden;
   backface-visibility: hidden;
+
+  background: #2FAFDE;
+  content: '';
+  height: 50%;
+  left: 0;
+  max-width: 100%;
+  position: absolute;
+  top: -5px;
+  transform: skewY(-1.5deg);
+  width: 100%;
+  z-index: -1;
 }
 
 #landing .header-light {
@@ -148,27 +154,44 @@
   margin: 2em auto;
 }
 
+@media (min-width: 1000px) {
+  #landing .icon-voice {
+    max-width: 300px;
+  }
+}
+
+@media (min-width: 1900px) {
+  #landing .icon-voice {
+    max-width: 400px;
+  }
+}
+
 .screens-container {
   position: relative;
-  height: 500px;
-  margin: 1em 0;
-}
-
-@media (min-width: 400px) {
-  .screens-container {
-    height: 600px;
-  }
-}
-
-@media (min-width: 480px) {
-  .screens-container {
-    height: 650px;
-  }
+  height: 250px;
+  margin: auto;
+  max-width: 75%;
 }
 
 @media (min-width: 600px) {
   .screens-container {
     height: 300px;
+    max-width: 60%;
+  }
+}
+
+@media (min-width: 900px) {
+  .screens-container {
+    margin: auto;
+    max-width: 700px;
+    height: 500px;
+  }
+}
+
+@media (min-width: 1900px) {
+  .screens-container {
+    max-width: 800px;
+    height: 600px;
   }
 }
 
@@ -188,22 +211,12 @@
   }
 }
 
-
 .icon-screens {
+  max-width: 80%;
+  z-index: 2;
+  margin:auto;
   position:absolute;
-  max-width: 200%;
-  margin: auto;
-  left: -50%;
-}
-
-@media (min-width: 600px) {
-  .icon-screens {
-    max-width: 80%;
-    z-index: 2;
-    margin:auto;
-    position:absolute;
-    top: 50px;
-    left:0;
-    right:0;
-  }
+  top: 50px;
+  left:0;
+  right:0;
 }

--- a/app/src/sass/_lists.scss
+++ b/app/src/sass/_lists.scss
@@ -18,3 +18,18 @@
 .bubble img {
   border-radius: 100px;
 }
+
+@media (min-width: 600px) {
+  .link-list {
+    -webkit-flex-flow: row wrap;
+    flex-flow: row wrap;
+
+    display: -moz-box;
+    display: -ms-flexbox;
+    display: -webkit-box;
+    display: -webkit-flex;
+    display: flex;
+
+    justify-content: space-around;
+  }
+}


### PR DESCRIPTION
For Issue: https://github.com/open-austin/budgetparty/issues/208

Modified the SCSS of Budget Party's Landing page to be more responsive to Desktop & Mobile. This should define breaks at more reasonable levels (`600px`, 900px`, 1900px`) by modifying height and width elements.

Also removed the static `500px` width definition in `index.scss`